### PR TITLE
Fix/confirming issue

### DIFF
--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -149,8 +149,12 @@ async function handleTransaction(
     onTxConfirmed: async (receipt: TransactionReceipt) => {
       state.receipt = receipt;
 
-      const confirmedAt = await getTxConfirmedAt(receipt);
-      state.confirmedAt = dateTimeLabelFor(confirmedAt);
+      try {
+        const confirmedAt = await getTxConfirmedAt(receipt);
+        state.confirmedAt = dateTimeLabelFor(confirmedAt);
+      } catch (error) {
+        state.confirmedAt = dateTimeLabelFor(new Date());
+      }
 
       if (currentActionIndex.value >= actions.value.length - 1) {
         emit('success', { receipt, confirmedAt: state.confirmedAt });


### PR DESCRIPTION
# Description
  While approving, it still shows the "confirming".
This is because the error is happening when get the block using getBlock(). Need to investigate more.
For now, I fixed this issue manually.