### PR TITLE
fix: SYMMv2 price in swap

### DIFF
--- a/src/composables/queries/useTokenPricesQuery.ts
+++ b/src/composables/queries/useTokenPricesQuery.ts
@@ -33,22 +33,22 @@ export default function useTokenPricesQuery(
   const queryKey = reactive(QUERY_KEYS.Tokens.Prices(networkId, addresses));
   const { currency } = useUserSettings();
 
-  // TODO: kill this with fire as soon as Coingecko supports wstETH
-  async function injectSymmV2PriceOnCelo(prices: TokenPrices): Promise<TokenPrices> {
-// get SYMM price from v1 subgraph // todo: remove once symmv2 is supported
-console.log('SYMM PRICE');
-      const symm2address = '0x8427bd503dd3169ccc9aff7326c15258bc305478';
-      const url =
-        'https://api.thegraph.com/subgraphs/name/centfinance/symmetricv1celo';
-      const subgraphRes = await subgraphRequest(
-        url,
-        useSymmetricQueries['getSYMM2PriceCELO']
-      );
-      const symmPrice = subgraphRes?.tokenPrices[0].price;
-      console.log(symmPrice);
-      prices[symm2address] = {
-        [currency.value]: symmPrice
-      };
+  // TODO: kill this with fire as soon as Coingecko supports symmv2
+  async function injectSymmV2PriceOnCelo(
+    prices: TokenPrices
+  ): Promise<TokenPrices> {
+    // get SYMM price from v1 subgraph
+    const symm2address = '0x8427bD503dd3169cCC9aFF7326c15258Bc305478';
+    const url =
+      'https://api.thegraph.com/subgraphs/name/centfinance/symmetricv1celo';
+    const subgraphRes = await subgraphRequest(
+      url,
+      useSymmetricQueries['getSYMM2PriceCELO']
+    );
+    const symmPrice = subgraphRes?.tokenPrices[0].price;
+    prices[symm2address] = {
+      [currency.value]: Number((+symmPrice).toFixed(6))
+    };
     return prices;
   }
 


### PR DESCRIPTION
# Description

SYMMv2 token price wasn't showing in tokens list and swap screen. Coingecko doesn't provide SYMMv2 price yet so tried to get the price from Symmetric V1 pools subgraph (symmetricv1celo).

## Type of change

- updated `symm2address` with its original address instead of lowercase address
- converted SYMMv2 price from `string` to `number` with 6 decimals in `prices` array

## How should this be tested?

Navigate to the trade(swap) screen and check the tokens list or select SYMMv2 token in the list

- Test A
 
<img width="449" alt="image" src="https://user-images.githubusercontent.com/66651502/173068920-4454487c-f86f-477d-9f00-8294e714d2e2.png">

- Test B

<img width="456" alt="image" src="https://user-images.githubusercontent.com/66651502/173069054-3f91429b-b30d-4a43-aaf3-bba9b87e85a8.png">

## Checklist:

- I have performed a self-review of my own code
- I have commented my code where relevant, particularly in hard-to-understand areas
- My changes generate no new console warnings
- The base of this PR is `develop`
