### PR TITLE
cREAL, mcREAL and cDEFI pricing injected

### DIFF
--- a/src/composables/queries/useTokenPricesQuery.ts
+++ b/src/composables/queries/useTokenPricesQuery.ts
@@ -115,7 +115,7 @@ export default function useTokenPricesQuery(
         prices['0x00Be915B9dCf56a3CBE739D9B9c202ca692409EC'][currency.value] ||
         0;
 
-      const symm2address = '0xa287a3722c367849efa5c76e96be36efd65c290e';
+      const symm2address = '0xA287A3722c367849eFA5c76e96BE36efd65C290e';
       const url =
         'https://api.thegraph.com/subgraphs/name/centfinance/symmetric-v2-celo';
       const subgraphRes = await subgraphRequest(

--- a/src/composables/queries/usecDEFISharesQueries.json
+++ b/src/composables/queries/usecDEFISharesQueries.json
@@ -1,0 +1,16 @@
+{
+  "custom": {},
+  "getCDEFISharesCELO": {
+    "pools": {
+      "__args": {
+        "where": {
+          "id": "0xa287a3722c367849efa5c76e96be36efd65c290e000100000000000000000020"
+        }
+      },
+      "id": true,
+      "symbol": true,
+      "name": true,
+      "totalShares": true
+    }
+  }
+}

--- a/src/composables/queries/usecREALQueries.json
+++ b/src/composables/queries/usecREALQueries.json
@@ -1,0 +1,20 @@
+{
+  "custom": {},
+  "getCREALPriceCELO": {
+    "tokenPrices": {
+      "__args": {
+        "first": 1,
+        "where": {
+          "id": "0xe8537a3d056da446677b9e9d6c5db704eaab4787"
+        }
+      },
+      "id": true,
+      "symbol": true,
+      "name": true,
+      "decimals": true,
+      "price": true,
+      "poolLiquidity": true,
+      "poolTokenId": true
+    }
+  }
+}

--- a/src/composables/queries/usemcDEFIQueries.json
+++ b/src/composables/queries/usemcDEFIQueries.json
@@ -1,0 +1,17 @@
+{
+  "custom": {},
+  "getCDEFIBalanceCELO": {
+    "poolTokens": {
+      "__args": {
+        "where": {
+          "poolId": "0xa287a3722c367849efa5c76e96be36efd65c290e000100000000000000000020"
+        }
+      },
+      "id": true,
+      "symbol": true,
+      "name": true,
+      "balance": true,
+      "decimals": true
+    }
+  }
+}

--- a/src/composables/queries/usemcREALQueries.json
+++ b/src/composables/queries/usemcREALQueries.json
@@ -1,0 +1,20 @@
+{
+  "custom": {},
+  "getMCREALPriceCELO": {
+    "tokenPrices": {
+      "__args": {
+        "first": 1,
+        "where": {
+          "id": "0x9802d866fde4563d088a6619f7cef82c0b991a55"
+        }
+      },
+      "id": true,
+      "symbol": true,
+      "name": true,
+      "decimals": true,
+      "price": true,
+      "poolLiquidity": true,
+      "poolTokenId": true
+    }
+  }
+}


### PR DESCRIPTION
# Description

cREAL and mcREAL pricing data doesn't exist on CoinGecko so we are substituting price data for these tokens from our own Subgraph.

cDEFI index also doesn't have price data so we calculate pricing data based on the tokens within that index.

A longer term replacement will be developed after to handle pricing data that doesn't exist on CoinGecko.