### PR TITLE
Added chainId when setting up WalletConnect connection

### DIFF
--- a/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
+++ b/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
@@ -10,7 +10,8 @@ export class WalletConnectConnector extends Connector {
     const provider = new WalletConnectProvider({
       rpc: {
         [configService.env.NETWORK]: configService.rpc
-      }
+      },
+      chainId: configService.env.NETWORK
     });
     this.provider = provider;
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any new dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Connect using WalletConnect with the Minerva wallet. When connecting, the network should identify as Gnosis. Note, we also identify the network for Celo but Minerva's wallet doesn't support Celo so the test should be on the Gnosis network.
- [ ] Check WalletConnect on the Celo network using any wallet to ensure that WC still works on Celo.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] My changes generate no new console warnings
- [X] The base of this PR is `master` if hotfix, `develop` if not
